### PR TITLE
Fix Vercel Ruby version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_RUBY_VERSION": "2.7.6"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` so Vercel uses Ruby 2.7.6

## Testing
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d2ea42948323a24c02cde6621e4d