### PR TITLE
Ensure google-services.json during prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile",
-    "prebuild": "expo prebuild --clean",
+    "prebuild": "node ./scripts/copyGoogleServices.js && expo prebuild --clean",
     "android": "expo run:android",
     "android:prod": "expo run:android --variant release",
     "android:profile": "BSKY_PROFILE=1 expo run:android --variant release",

--- a/scripts/copyGoogleServices.js
+++ b/scripts/copyGoogleServices.js
@@ -1,0 +1,12 @@
+const fs = require('fs')
+
+const src = 'google-services.json'
+const example = 'google-services.json.example'
+if (!fs.existsSync(src)) {
+  if (fs.existsSync(example)) {
+    fs.copyFileSync(example, src)
+    console.log(`Copied ${example} to ${src}`)
+  } else {
+    console.error(`Neither ${src} nor ${example} found`)
+  }
+}


### PR DESCRIPTION
## Summary
- add script to copy `google-services.json.example` if `google-services.json` is missing
- run this script in the `prebuild` npm script

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6874dac15fc48323a81fb224369523a5