### PR TITLE
Fix Expo build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile",
     "build-web": "expo export:web && node ./scripts/post-web-build.js",
-    "build": "expo export --platform web",
+    "build": "expo export:web",
     "build-embed": "cd bskyembed && yarn build && yarn build-snippet && cd .. && node ./scripts/post-embed-build.js",
     "start": "expo start --dev-client",
     "start:prod": "expo start --dev-client --no-dev --minify",


### PR DESCRIPTION
## Summary
- fix Vercel build by using `expo export:web`

## Testing
- `yarn lint` *(fails: couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6874e900efdc8323a4c36e15f43031ec