### PR TITLE
Change AI icon and link behavior

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -41,7 +41,6 @@ import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
-import {Brain_Stroke2_Corner0_Rounded as Brain} from '#/components/icons/Brain'
 import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
@@ -207,10 +206,16 @@ export function BottomBar({navigation}: BottomTabBarProps) {
             <Btn
               icon={
                 <View style={styles.ctrlIconSizingWrapper}>
-                  <Brain
-                    width={iconWidth - 1}
-                    style={[styles.ctrlIcon, pal.text, styles.aiIcon]}
-                  />
+                  <Text
+                    aria-hidden={true}
+                    style={[
+                      styles.ctrlIcon,
+                      pal.text,
+                      styles.aiIcon,
+                      {fontSize: iconWidth + 2},
+                    ]}>
+                    🤖
+                  </Text>
                   <Text
                     style={{
                       position: 'absolute',

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -27,7 +27,7 @@ import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
-import {Brain_Stroke2_Corner0_Rounded as Brain} from '#/components/icons/Brain'
+import {Pressable} from 'react-native'
 import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
@@ -114,18 +114,26 @@ export function BottomBarWeb() {
               )
             }}
           </NavItem>
-          <Link
-            href="https://chat.aiturklaw.com"
+          <Pressable
+            onPress={() => {
+              // open in the current tab
+              window.location.href = 'https://chat.aiturklaw.com'
+            }}
             style={[styles.ctrl, a.pb_lg]}
-            aria-role="link"
-            aria-label="AI Chat"
+            accessibilityRole="link"
+            accessibilityLabel="AI Chat"
             accessible={true}>
             <View style={styles.ctrlIconSizingWrapper}>
-              <Brain
+              <Text
                 aria-hidden={true}
-                width={iconWidth - 1}
-                style={[styles.ctrlIcon, t.atoms.text, styles.aiIcon]}
-              />
+                style={[
+                  styles.ctrlIcon,
+                  t.atoms.text,
+                  styles.aiIcon,
+                  {fontSize: iconWidth + 2},
+                ]}>
+                🤖
+              </Text>
               <Text
                 style={{
                   position: 'absolute',
@@ -136,7 +144,7 @@ export function BottomBarWeb() {
                 AI
               </Text>
             </View>
-          </Link>
+          </Pressable>
 
           {hasSession && (
             <>


### PR DESCRIPTION
## Summary
- use a robot emoji instead of the brain icon for the AI chat entry
- keep "AI" label under the icon
- open the AI chat in the current tab on the web

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875187844cc8323b08e6dae77196afa