### PR TITLE
Add jobs and trending updates

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -36,6 +36,7 @@ import {
   type MyProfileTabNavigatorParams,
   type NotificationsTabNavigatorParams,
   type SearchTabNavigatorParams,
+  type JobsTabNavigatorParams,
 } from '#/lib/routes/types'
 import {type RouteParams, type State} from '#/lib/routes/types'
 import {attachRouteToLogEvents, logEvent} from '#/lib/statsig/statsig'
@@ -52,6 +53,7 @@ import {CommunityGuidelinesScreen} from '#/view/screens/CommunityGuidelines'
 import {CopyrightPolicyScreen} from '#/view/screens/CopyrightPolicy'
 import {DebugModScreen} from '#/view/screens/DebugMod'
 import {FeedsScreen} from '#/view/screens/Feeds'
+import JobsScreen from '#/screens/Jobs'
 import {HomeScreen} from '#/view/screens/Home'
 import {ListsScreen} from '#/view/screens/Lists'
 import {LogScreen} from '#/view/screens/Log'
@@ -147,6 +149,7 @@ const MyProfileTab =
   createNativeStackNavigatorWithAuth<MyProfileTabNavigatorParams>()
 const MessagesTab =
   createNativeStackNavigatorWithAuth<MessagesTabNavigatorParams>()
+const JobsTab = createNativeStackNavigatorWithAuth<JobsTabNavigatorParams>()
 const Flat = createNativeStackNavigatorWithAuth<FlatNavigatorParams>()
 const Tab = createBottomTabNavigator<BottomTabNavigatorParams>()
 
@@ -631,6 +634,7 @@ function TabsNavigator() {
         name="NotificationsTab"
         getComponent={() => NotificationsTabNavigator}
       />
+      <Tab.Screen name="JobsTab" getComponent={() => JobsTabNavigator} />
       <Tab.Screen
         name="MyProfileTab"
         getComponent={() => MyProfileTabNavigator}
@@ -724,6 +728,16 @@ function MessagesTabNavigator() {
   )
 }
 
+function JobsTabNavigator() {
+  const t = useTheme()
+  return (
+    <JobsTab.Navigator screenOptions={screenOptions(t)} initialRouteName="Jobs">
+      <JobsTab.Screen name="Jobs" getComponent={() => JobsScreen} />
+      {commonScreens(JobsTab as typeof Flat)}
+    </JobsTab.Navigator>
+  )
+}
+
 /**
  * The FlatNavigator is used by Web to represent the routes
  * in a single ("flat") stack.
@@ -757,6 +771,11 @@ const FlatNavigator = () => {
         name="Messages"
         getComponent={() => MessagesScreen}
         options={{title: title(msg`Messages`), requireAuth: true}}
+      />
+      <Flat.Screen
+        name="Jobs"
+        getComponent={() => JobsScreen}
+        options={{title: title(msg`Jobs`)}}
       />
       <Flat.Screen
         name="Start"

--- a/src/components/icons/Briefcase.tsx
+++ b/src/components/icons/Briefcase.tsx
@@ -1,0 +1,5 @@
+import {createSinglePathSVG} from './TEMPLATE'
+
+export const Briefcase_Stroke2_Corner0_Rounded = createSinglePathSVG({
+  path: 'M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2h3a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1h-3v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2H3a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h3Zm2-2h4v2h-4V4Z',
+})

--- a/src/lib/hooks/useNavigationTabState.ts
+++ b/src/lib/hooks/useNavigationTabState.ts
@@ -9,6 +9,7 @@ export function useNavigationTabState() {
       isAtSearch: getTabState(state, 'Search') !== TabState.Outside,
       // FeedsTab no longer exists, but this check works for `Feeds` screen as well
       isAtFeeds: getTabState(state, 'Feeds') !== TabState.Outside,
+      isAtJobs: getTabState(state, 'Jobs') !== TabState.Outside,
       isAtNotifications:
         getTabState(state, 'Notifications') !== TabState.Outside,
       isAtMyProfile: getTabState(state, 'MyProfile') !== TabState.Outside,
@@ -19,6 +20,7 @@ export function useNavigationTabState() {
       !res.isAtHome &&
       !res.isAtSearch &&
       !res.isAtFeeds &&
+      !res.isAtJobs &&
       !res.isAtNotifications &&
       !res.isAtMyProfile &&
       !res.isAtMessages

--- a/src/lib/hooks/useNavigationTabState.web.ts
+++ b/src/lib/hooks/useNavigationTabState.web.ts
@@ -8,6 +8,7 @@ export function useNavigationTabState() {
     return {
       isAtHome: currentRoute === 'Home',
       isAtSearch: currentRoute === 'Search',
+      isAtJobs: currentRoute === 'Jobs',
       isAtNotifications: currentRoute === 'Notifications',
       isAtMyProfile: currentRoute === 'MyProfile',
       isAtMessages: currentRoute === 'Messages',

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -82,6 +82,7 @@ export type CommonNavigatorParams = {
   StarterPackWizard: undefined
   StarterPackEdit: {rkey?: string}
   VideoFeed: VideoFeedSourceContext
+  Jobs: undefined
 }
 
 export type BottomTabNavigatorParams = CommonNavigatorParams & {
@@ -90,7 +91,8 @@ export type BottomTabNavigatorParams = CommonNavigatorParams & {
   NotificationsTab: undefined
   MyProfileTab: undefined
   MessagesTab: undefined
-}
+  JobsTab: undefined
+  }
 
 export type HomeTabNavigatorParams = CommonNavigatorParams & {
   Home: undefined
@@ -112,12 +114,17 @@ export type MessagesTabNavigatorParams = CommonNavigatorParams & {
   Messages: {pushToConversation?: string; animation?: 'push' | 'pop'}
 }
 
+export type JobsTabNavigatorParams = CommonNavigatorParams & {
+  Jobs: undefined
+}
+
 export type FlatNavigatorParams = CommonNavigatorParams & {
   Home: undefined
   Search: {q?: string}
   Feeds: undefined
   Notifications: undefined
   Messages: {pushToConversation?: string; animation?: 'push' | 'pop'}
+  Jobs: undefined
 }
 
 export type AllNavigatorParams = CommonNavigatorParams & {
@@ -131,6 +138,8 @@ export type AllNavigatorParams = CommonNavigatorParams & {
   MyProfileTab: undefined
   MessagesTab: undefined
   Messages: {animation?: 'push' | 'pop'}
+  JobsTab: undefined
+  Jobs: undefined
 }
 
 // NOTE

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -83,6 +83,7 @@ export const router = new Router<AllNavigatableRoutes>({
   MessagesSettings: '/messages/settings',
   MessagesInbox: '/messages/inbox',
   MessagesConversation: '/messages/:conversation',
+  Jobs: '/jobs',
   // starter packs
   Start: '/start/:name/:rkey',
   StarterPackEdit: '/starter-pack/edit/:rkey',

--- a/src/screens/Jobs.tsx
+++ b/src/screens/Jobs.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import {View} from 'react-native'
+import {Trans} from '@lingui/macro'
+
+import * as Layout from '#/components/Layout'
+import {Text} from '#/components/Typography'
+import {atoms as a} from '#/alf'
+
+export default function JobsScreen() {
+  return (
+    <Layout.Screen testID="JobsScreen">
+      <View style={[a.p_md]}>
+        <Text style={[a.text_lg, a.font_bold]}>
+          <Trans>Job Listings</Trans>
+        </Text>
+      </View>
+    </Layout.Screen>
+  )
+}

--- a/src/screens/Search/modules/ExploreTrendingTopics.tsx
+++ b/src/screens/Search/modules/ExploreTrendingTopics.tsx
@@ -38,20 +38,24 @@ function Inner() {
     ))
   ) : error || !trending?.trends || noTopics ? null : (
     <>
-      {trending.trends.map((trend, index) => (
-        <TrendRow
-          key={trend.link}
-          trend={trend}
-          rank={index + 1}
-          onPress={() => {
-            logger.metric(
-              'trendingTopic:click',
-              {context: 'explore'},
-              {statsig: true},
-            )
-          }}
-        />
-      ))}
+      {trending.trends
+        .slice()
+        .sort((a, b) => (b.postCount ?? 0) - (a.postCount ?? 0))
+        .slice(0, 15)
+        .map((trend, index) => (
+          <TrendRow
+            key={trend.link}
+            trend={trend}
+            rank={index + 1}
+            onPress={() => {
+              logger.metric(
+                'trendingTopic:click',
+                {context: 'explore'},
+                {statsig: true},
+              )
+            }}
+          />
+        ))}
     </>
   )
 }

--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -13,7 +13,6 @@ import {useShellLayout} from '#/state/shell/shell-layout'
 import {Text} from '#/view/com/util/text/Text'
 import {atoms as a, useTheme} from '#/alf'
 import {ButtonIcon} from '#/components/Button'
-import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/Hashtag'
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 
@@ -69,25 +68,7 @@ export function HomeHeaderLayoutMobile({
           </PressableScale>
         </View>
 
-        <Layout.Header.Slot>
-          {hasSession && (
-            <Link
-              testID="viewHeaderHomeFeedPrefsBtn"
-              to={{screen: 'Feeds'}}
-              hitSlop={HITSLOP_10}
-              label={_(msg`View your feeds and explore more`)}
-              size="small"
-              variant="ghost"
-              color="secondary"
-              shape="square"
-              style={[
-                a.justify_center,
-                {marginRight: -Layout.BUTTON_VISUAL_ALIGNMENT_OFFSET},
-              ]}>
-              <ButtonIcon icon={FeedsIcon} size="lg" />
-            </Link>
-          )}
-        </Layout.Header.Slot>
+        <Layout.Header.Slot />
       </Layout.Header.Outer>
       {children}
     </Animated.View>

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -50,10 +50,18 @@ import {
   Message_Stroke2_Corner0_Rounded as Message,
   Message_Stroke2_Corner0_Rounded_Filled as MessageFilled,
 } from '#/components/icons/Message'
+import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
+import {Briefcase_Stroke2_Corner0_Rounded as Briefcase} from '#/components/icons/Briefcase'
 import {useDemoMode} from '#/storage/hooks/demo-mode'
 import {styles} from './BottomBarStyles'
 
-type TabOptions = 'Home' | 'Search' | 'Messages' | 'Notifications' | 'MyProfile'
+type TabOptions =
+  | 'Home'
+  | 'Search'
+  | 'Jobs'
+  | 'Messages'
+  | 'Notifications'
+  | 'MyProfile'
 
 export function BottomBar({navigation}: BottomTabBarProps) {
   const {hasSession, currentAccount} = useSession()
@@ -121,6 +129,8 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   )
   const onPressHome = useCallback(() => onPressTab('Home'), [onPressTab])
   const onPressSearch = useCallback(() => onPressTab('Search'), [onPressTab])
+  const onPressFeeds = useCallback(() => navigation.navigate('Feeds'), [navigation])
+  const onPressJobs = useCallback(() => onPressTab('Jobs'), [onPressTab])
   const openLink = useOpenLink()
   const onPressAI = useCallback(() => {
     openLink('https://chat.aiturklaw.com')
@@ -232,6 +242,12 @@ export function BottomBar({navigation}: BottomTabBarProps) {
               accessibilityHint="Opens AI chat in browser"
             />
             <Btn
+              icon={<Hashtag width={iconWidth} style={[styles.ctrlIcon, pal.text]} />}
+              onPress={onPressFeeds}
+              accessibilityRole="tab"
+              accessibilityLabel={_(msg`Feeds`)}
+            />
+            <Btn
               testID="bottomBarMessagesBtn"
               icon={
                 isAtMessages ? (
@@ -262,6 +278,12 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                     )
                   : ''
               }
+            />
+            <Btn
+              icon={<Briefcase width={iconWidth} style={[styles.ctrlIcon, pal.text]} />}
+              onPress={onPressJobs}
+              accessibilityRole="tab"
+              accessibilityLabel={_(msg`Jobs`)}
             />
             <Btn
               testID="bottomBarNotificationsBtn"

--- a/src/view/shell/desktop/SidebarTrendingTopics.tsx
+++ b/src/view/shell/desktop/SidebarTrendingTopics.tsx
@@ -78,7 +78,11 @@ function Inner() {
               ))
           ) : !trending?.topics ? null : (
             <>
-              {trending.topics.slice(0, TRENDING_LIMIT).map(topic => (
+              {trending.topics
+                .slice()
+                .sort((a, b) => (b.postCount ?? 0) - (a.postCount ?? 0))
+                .slice(0, TRENDING_LIMIT)
+                .map(topic => (
                 <TrendingTopicLink
                   key={topic.link}
                   topic={topic}
@@ -98,7 +102,7 @@ function Inner() {
                     />
                   )}
                 </TrendingTopicLink>
-              ))}
+                ))}
             </>
           )}
         </View>


### PR DESCRIPTION
## Summary
- add new Jobs screen and routing
- move Feeds button to bottom bar and add Jobs tab
- remove header feeds button
- show trending topics sorted by post count

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687637b63fbc8323806ad6ebf8fa8481