### PR TITLE
Fix theme color access guards

### DIFF
--- a/src/alf/util/systemUI.ts
+++ b/src/alf/util/systemUI.ts
@@ -6,7 +6,10 @@ import {type Theme} from '../types'
 export function setSystemUITheme(themeType: 'theme' | 'lightbox', t: Theme) {
   if (isAndroid) {
     if (themeType === 'theme') {
-      SystemUI.setBackgroundColorAsync(t.atoms.bg.backgroundColor)
+      const color = t?.atoms?.bg?.backgroundColor
+      if (color) {
+        SystemUI.setBackgroundColorAsync(color)
+      }
     } else {
       SystemUI.setBackgroundColorAsync('black')
     }

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -55,12 +55,15 @@ function updateDocument(theme: ThemeName) {
 }
 
 export function getBackgroundColor(theme: ThemeName): string {
+  const fallback = '#000'
   switch (theme) {
     case 'light':
-      return light.atoms.bg.backgroundColor
+      return light?.atoms?.bg?.backgroundColor ?? fallback
     case 'dark':
-      return dark.atoms.bg.backgroundColor
+      return dark?.atoms?.bg?.backgroundColor ?? fallback
     case 'dim':
-      return dim.atoms.bg.backgroundColor
+      return dim?.atoms?.bg?.backgroundColor ?? fallback
+    default:
+      return fallback
   }
 }


### PR DESCRIPTION
## Summary
- add fallbacks when accessing theme background color
- guard system UI background color update on Android

## Testing
- `yarn lint` *(fails: ESLint config not found)*
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a931115508323bfb5bb24dffb2717