### PR TITLE
Fix theme lookup in useTheme

### DIFF
--- a/src/alf/index.tsx
+++ b/src/alf/index.tsx
@@ -142,6 +142,9 @@ export function useTheme(theme?: ThemeName) {
     if (!alf) {
       return defaultTheme
     }
-    return theme ? alf.themes[theme] : alf.theme
+    if (theme) {
+      return alf.themes[theme] ?? defaultTheme
+    }
+    return alf.theme ?? defaultTheme
   }, [theme, alf])
 }


### PR DESCRIPTION
## Summary
- default to defaultTheme when requested theme is missing

## Testing
- `yarn test` *(fails: `node: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a9ef1a6d08323802d121cadcfedfc