### PR TITLE
Fix theme access null errors

### DIFF
--- a/src/alf/index.tsx
+++ b/src/alf/index.tsx
@@ -142,9 +142,10 @@ export function useTheme(theme?: ThemeName) {
     if (!alf) {
       return defaultTheme
     }
-    if (theme) {
-      return alf.themes[theme] ?? defaultTheme
+    const t = theme ? alf.themes[theme] : alf.theme
+    if (!t?.atoms) {
+      return defaultTheme
     }
-    return alf.theme ?? defaultTheme
+    return t
   }, [theme, alf])
 }

--- a/src/lib/custom-animations/LikeIcon.tsx
+++ b/src/lib/custom-animations/LikeIcon.tsx
@@ -114,7 +114,7 @@ export function AnimatedLikeIcon({
               entering={circle2Keyframe.duration(300)}
               style={{
                 position: 'absolute',
-                backgroundColor: t.atoms.bg.backgroundColor,
+                backgroundColor: t.atoms?.bg?.backgroundColor,
                 top: 0,
                 left: 0,
                 width: size,

--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -103,7 +103,7 @@ export function AnimatedLikeIcon({
         ref={circle2Ref}
         style={{
           position: 'absolute',
-          backgroundColor: t.atoms.bg.backgroundColor,
+          backgroundColor: t.atoms?.bg?.backgroundColor,
           top: 0,
           left: 0,
           width: size,

--- a/src/lib/hooks/useOpenLink.ts
+++ b/src/lib/hooks/useOpenLink.ts
@@ -62,7 +62,7 @@ export function useOpenLink() {
             WebBrowser.openBrowserAsync(url, {
               presentationStyle:
                 WebBrowser.WebBrowserPresentationStyle.PAGE_SHEET,
-              toolbarColor: t.atoms.bg.backgroundColor,
+              toolbarColor: t.atoms?.bg?.backgroundColor,
               controlsColor: t.palette.primary_500,
               createTask: false,
             }).catch(err => {

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -274,7 +274,7 @@ let PagerTabBar = ({
   return (
     <Animated.View
       pointerEvents={isIOS ? 'auto' : 'box-none'}
-      style={[styles.tabBarMobile, headerTransform, t.atoms.bg]}>
+      style={[styles.tabBarMobile, headerTransform, t.atoms?.bg]}>
       <View
         ref={headerRef}
         pointerEvents={isIOS ? 'auto' : 'box-none'}

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -313,7 +313,7 @@ export function TabBar({
   return (
     <View
       testID={testID}
-      style={[t.atoms.bg, a.flex_row]}
+      style={[t.atoms?.bg, a.flex_row]}
       accessibilityRole="tablist">
       <BlockDrawerGesture>
         <ScrollView
@@ -424,7 +424,7 @@ function TabBarItem({
       <PressableWithHover
         testID={`${testID}-selector-${index}`}
         style={styles.item}
-        hoverStyle={t.atoms.bg_contrast_25}
+        hoverStyle={t.atoms?.bg_contrast_25}
         onPress={() => onPressItem(index)}
         accessibilityRole="tab">
         <Animated.View style={[style, styles.itemInner]}>

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -92,7 +92,7 @@ export function TabBar({
   return (
     <View
       testID={testID}
-      style={[t.atoms.bg, styles.outer]}
+      style={[t.atoms?.bg, styles.outer]}
       accessibilityRole="tablist">
       <DraggableScrollView
         testID={`${testID}-selector`}
@@ -108,7 +108,7 @@ export function TabBar({
               key={`${item}-${i}`}
               ref={node => (itemRefs.current[i] = node as any)}
               style={styles.item}
-              hoverStyle={t.atoms.bg_contrast_25}
+              hoverStyle={t.atoms?.bg_contrast_25}
               onPress={() => onPressItem(i)}
               accessibilityRole="tab">
               <View style={styles.itemInner}>

--- a/src/view/shell/Composer.ios.tsx
+++ b/src/view/shell/Composer.ios.tsx
@@ -32,7 +32,7 @@ export function Composer({}: {winHeight: number}) {
       presentationStyle="pageSheet"
       animationType="slide"
       onRequestClose={() => ref.current?.onPressCancel()}>
-      <View style={[t.atoms.bg, a.flex_1]}>
+      <View style={[t.atoms?.bg, a.flex_1]}>
         <ComposePost
           cancelRef={ref}
           replyTo={state?.replyTo}

--- a/src/view/shell/Composer.tsx
+++ b/src/view/shell/Composer.tsx
@@ -43,7 +43,7 @@ export function Composer({winHeight}: {winHeight: number}) {
 
   return (
     <Animated.View
-      style={[a.absolute, a.inset_0, t.atoms.bg, wrapperAnimStyle]}
+      style={[a.absolute, a.inset_0, t.atoms?.bg, wrapperAnimStyle]}
       aria-modal
       accessibilityViewIsModal>
       <ComposePost

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -92,8 +92,8 @@ function Inner({state}: {state: ComposerOpts}) {
           style={[
             styles.container,
             !gtMobile && styles.containerMobile,
-            t.atoms.bg,
-            t.atoms.border_contrast_medium,
+            t.atoms?.bg,
+            t.atoms?.border_contrast_medium,
             !reduceMotionEnabled && [
               a.zoom_fade_in,
               {animationDelay: 0.1},

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -1,5 +1,5 @@
 import React, {type ComponentProps} from 'react'
-import {Linking, ScrollView, TouchableOpacity, View} from 'react-native'
+import {ScrollView, TouchableOpacity, View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {msg, Plural, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -22,8 +22,8 @@ import {useSetDrawerOpen} from '#/state/shell'
 import {formatCount} from '#/view/com/util/numeric/format'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
-import {atoms as a, tokens, useTheme, web} from '#/alf'
-import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Button} from '#/components/Button'
 import {Divider} from '#/components/Divider'
 import {
   Bell_Filled_Corner0_Rounded as BellFilled,
@@ -243,7 +243,7 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
   return (
     <View
       testID="drawer"
-      style={[a.flex_1, a.border_r, t.atoms.bg, t.atoms.border_contrast_low]}>
+      style={[a.flex_1, a.border_r, t.atoms?.bg, t.atoms?.border_contrast_low]}>
       <ScrollView
         style={[a.flex_1]}
         contentContainerStyle={[
@@ -306,7 +306,6 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
 }
 DrawerContent = React.memo(DrawerContent)
 export {DrawerContent}
-
 
 interface MenuItemProps extends ComponentProps<typeof PressableScale> {
   icon: JSX.Element

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {View} from 'react-native'
+import {Pressable} from 'react-native'
 import Animated from 'react-native-reanimated'
 import {msg, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -26,7 +27,6 @@ import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
-import {Pressable} from 'react-native'
 import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
@@ -77,9 +77,9 @@ export function BottomBarWeb() {
       style={[
         styles.bottomBar,
         styles.bottomBarWeb,
-        t.atoms.bg,
+        t.atoms?.bg,
         hideBorder
-          ? {borderColor: t.atoms.bg.backgroundColor}
+          ? {borderColor: t.atoms?.bg?.backgroundColor}
           : t.atoms.border_contrast_low,
         footerMinimalShellTransform,
       ]}
@@ -121,6 +121,7 @@ export function BottomBarWeb() {
             style={[styles.ctrl, a.pb_lg]}
             accessibilityRole="link"
             accessibilityLabel="AI Chat"
+            accessibilityHint="Opens AI chat in the current tab"
             accessible={true}>
             <View style={styles.ctrlIconSizingWrapper}>
               <Text

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -4,7 +4,7 @@ import {useLingui} from '@lingui/react'
 import {useNavigation, useNavigationState} from '@react-navigation/native'
 
 import {getCurrentRoute} from '#/lib/routes/helpers'
-import {NavigationProp} from '#/lib/routes/types'
+import {type NavigationProp} from '#/lib/routes/types'
 import {emitSoftReset} from '#/state/events'
 import {usePinnedFeedsInfos} from '#/state/queries/feed'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
@@ -40,7 +40,7 @@ export function DesktopFeeds() {
               key={i}
               style={[
                 a.rounded_sm,
-                t.atoms.bg_contrast_25,
+                t.atoms?.bg_contrast_25,
                 {
                   height: 16,
                   width: i % 2 === 0 ? '60%' : '80%',

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -117,7 +117,7 @@ function ProfileCard() {
                   style={[
                     a.w_full,
                     a.transition_color,
-                    active ? t.atoms.bg_contrast_25 : a.transition_delay_50ms,
+                    active ? t.atoms?.bg_contrast_25 : a.transition_delay_50ms,
                     a.rounded_full,
                     a.justify_between,
                     a.align_center,
@@ -366,7 +366,7 @@ function NavItem({count, hasNew, href, icon, iconFilled, label}: NavItemProps) {
         a.outline_inset_1,
         a.transition_color,
       ]}
-      hoverStyle={t.atoms.bg_contrast_25}
+      hoverStyle={t.atoms?.bg_contrast_25}
       // @ts-expect-error the function signature differs on web -prf
       onPress={onPressWrapped}
       href={href}

--- a/src/view/shell/desktop/SidebarTrendingTopics.tsx
+++ b/src/view/shell/desktop/SidebarTrendingTopics.tsx
@@ -83,25 +83,25 @@ function Inner() {
                 .sort((a, b) => (b.postCount ?? 0) - (a.postCount ?? 0))
                 .slice(0, TRENDING_LIMIT)
                 .map(topic => (
-                <TrendingTopicLink
-                  key={topic.link}
-                  topic={topic}
-                  onPress={() => {
-                    logEvent('trendingTopic:click', {context: 'sidebar'})
-                  }}>
-                  {({hovered}) => (
-                    <TrendingTopic
-                      size="small"
-                      topic={topic}
-                      style={[
-                        hovered && [
-                          t.atoms.border_contrast_high,
-                          t.atoms.bg_contrast_25,
-                        ],
-                      ]}
-                    />
-                  )}
-                </TrendingTopicLink>
+                  <TrendingTopicLink
+                    key={topic.link}
+                    topic={topic}
+                    onPress={() => {
+                      logEvent('trendingTopic:click', {context: 'sidebar'})
+                    }}>
+                    {({hovered}) => (
+                      <TrendingTopic
+                        size="small"
+                        topic={topic}
+                        style={[
+                          hovered && [
+                            t.atoms?.border_contrast_high,
+                            t.atoms?.bg_contrast_25,
+                          ],
+                        ]}
+                      />
+                    )}
+                  </TrendingTopicLink>
                 ))}
             </>
           )}

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -174,7 +174,7 @@ export const Shell: React.FC = function ShellImpl() {
   }, [t])
 
   return (
-    <View testID="mobileShellView" style={[a.h_full, t.atoms.bg]}>
+    <View testID="mobileShellView" style={[a.h_full, t.atoms?.bg]}>
       <SystemBars
         style={{
           statusBar:


### PR DESCRIPTION
## Summary
- return default theme if atoms are missing
- safeguard toolbar color with optional chaining
- fix style references to theme atoms across views
- sort imports and add accessibility hint on bottom bar

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687aa394438c832392cba6ce485fbfa9