### PR TITLE
Fix theme import for useColorModeTheme

### DIFF
--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -3,7 +3,7 @@ import {type ColorSchemeName, useColorScheme} from 'react-native'
 
 import {isWeb} from '#/platform/detection'
 import {useThemePrefs} from '#/state/shell'
-import {dark, dim, light} from '#/alf/themes'
+import {dark, defaultTheme, dim, light} from '#/alf/themes'
 import {type ThemeName} from '#/alf/types'
 
 export function useColorModeTheme(): ThemeName {


### PR DESCRIPTION
## Summary
- fix missing `defaultTheme` import used in getBackgroundColor

## Testing
- `yarn lint` *(fails: ESLint couldn't find config)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687b663b6d8483238b8c52eaf2110a56