### PR TITLE
Fix theme mismatch causing bg errors

### DIFF
--- a/src/view/com/home/HomeHeaderLayout.web.tsx
+++ b/src/view/com/home/HomeHeaderLayout.web.tsx
@@ -7,8 +7,9 @@ import {useSession} from '#/state/session'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {HomeHeaderLayoutMobile} from '#/view/com/home/HomeHeaderLayoutMobile'
 import {Text} from '#/view/com/util/text/Text'
-import {useTheme} from '#/lib/ThemeContext'
+import {usePalette} from '#/lib/hooks/usePalette'
 import {atoms as a, useBreakpoints, useGutters} from '#/alf'
+import {useTheme} from '#/lib/ThemeContext'
 import {ButtonIcon} from '#/components/Button'
 import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/Hashtag'
 import * as Layout from '#/components/Layout'
@@ -34,6 +35,7 @@ function HomeHeaderLayoutDesktopAndTablet({
   tabBarAnchor: JSX.Element | null | undefined
 }) {
   const t = useTheme()
+  const pal = usePalette('default')
   const {headerHeight} = useShellLayout()
   const {hasSession} = useSession()
   const {_} = useLingui()
@@ -44,7 +46,7 @@ function HomeHeaderLayoutDesktopAndTablet({
       {hasSession && (
         <Layout.Center>
           <View
-            style={[a.flex_row, a.align_center, gutters, a.pt_md, t.atoms.bg]}>
+            style={[a.flex_row, a.align_center, gutters, a.pt_md, pal.view]}>
             <View style={{width: 34}} />
             <View style={[a.flex_1, a.align_center, a.justify_center]}>
               <Text
@@ -72,7 +74,7 @@ function HomeHeaderLayoutDesktopAndTablet({
       )}
       {tabBarAnchor}
       <Layout.Center
-        style={[a.sticky, a.z_10, a.align_center, t.atoms.bg, {top: 0}]}
+        style={[a.sticky, a.z_10, a.align_center, pal.view, {top: 0}]}
         onLayout={e => {
           headerHeight.set(e.nativeEvent.layout.height)
         }}>

--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -7,6 +7,7 @@ import {useMinimalShellHeaderTransform} from '#/lib/hooks/useMinimalShellTransfo
 import {emitSoftReset} from '#/state/events'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {Text} from '#/view/com/util/text/Text'
+import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from '#/lib/ThemeContext'
 import {atoms as a} from '#/alf'
 import * as Layout from '#/components/Layout'
@@ -18,6 +19,7 @@ export function HomeHeaderLayoutMobile({
   tabBarAnchor: JSX.Element | null | undefined
 }) {
   const t = useTheme()
+  const pal = usePalette('default')
   const {headerHeight} = useShellLayout()
   const headerMinimalShellTransform = useMinimalShellHeaderTransform()
   const playHaptic = useHaptics()
@@ -27,7 +29,7 @@ export function HomeHeaderLayoutMobile({
       style={[
         a.fixed,
         a.z_10,
-        t.atoms.bg,
+        pal.view,
         {
           top: 0,
           left: 0,


### PR DESCRIPTION
## Summary
- use background palette styles for home header layouts
- prevents errors when `useTheme` lacks `atoms`

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b691c266883239fa9c5a86b298248