### PR TITLE
Add job listings page and header icons

### DIFF
--- a/src/screens/Jobs.tsx
+++ b/src/screens/Jobs.tsx
@@ -1,19 +1,47 @@
 import React from 'react'
-import {View} from 'react-native'
+import {View, ScrollView} from 'react-native'
 import {Trans} from '@lingui/macro'
+import {Link} from '#/components/Link'
 
 import * as Layout from '#/components/Layout'
 import {Text} from '#/components/Typography'
 import {atoms as a} from '#/alf'
 
 export default function JobsScreen() {
+  const jobs = [
+    {
+      title: 'Frontend Developer',
+      company: 'Türklaw Inc.',
+      location: 'Istanbul',
+      link: 'https://www.linkedin.com/jobs',
+    },
+    {
+      title: 'Backend Developer',
+      company: 'Türklaw Inc.',
+      location: 'Ankara',
+      link: 'https://www.linkedin.com/jobs',
+    },
+  ]
+
   return (
     <Layout.Screen testID="JobsScreen">
-      <View style={[a.p_md]}>
-        <Text style={[a.text_lg, a.font_bold]}>
+      <ScrollView contentContainerStyle={[a.p_md, a.gap_md]}>
+        <Text style={[a.text_lg, a.font_bold, a.mb_md]}>
           <Trans>Job Listings</Trans>
         </Text>
-      </View>
+        {jobs.map(job => (
+          <Link
+            key={job.title}
+            to={job.link}
+            style={[a.p_md, a.border, a.rounded_md]}
+          >
+            <Text style={[a.text_md, a.font_bold]}>{job.title}</Text>
+            <Text style={[a.text_sm]}>
+              {job.company} - {job.location}
+            </Text>
+          </Link>
+        ))}
+      </ScrollView>
     </Layout.Screen>
   )
 }

--- a/src/screens/Search/modules/ExploreTrendingTopics.tsx
+++ b/src/screens/Search/modules/ExploreTrendingTopics.tsx
@@ -94,7 +94,7 @@ export function TrendRow({
   return (
     <Link
       testID={trend.link}
-      label={_(msg`Browse topic ${trend.displayName}`)}
+      label={_(msg`Browse topic #${trend.displayName}`)}
       to={trend.link}
       onPress={onPress}
       style={[a.border_b, t.atoms.border_contrast_low]}
@@ -119,7 +119,9 @@ export function TrendRow({
                 <Text
                   style={[a.text_md, a.font_bold, a.leading_tight]}
                   numberOfLines={1}>
-                  {trend.displayName}
+                  {trend.displayName.startsWith('#')
+                    ? trend.displayName
+                    : `#${trend.displayName}`}
                 </Text>
               </View>
               <View

--- a/src/view/com/home/HomeHeaderLayout.web.tsx
+++ b/src/view/com/home/HomeHeaderLayout.web.tsx
@@ -1,4 +1,4 @@
-import {View} from 'react-native'
+import {View, StyleSheet} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import type React from 'react'
@@ -12,6 +12,16 @@ import {atoms as a, useBreakpoints, useGutters} from '#/alf'
 import {useTheme} from '#/lib/ThemeContext'
 import {ButtonIcon} from '#/components/Button'
 import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/Hashtag'
+import {
+  Message_Stroke2_Corner0_Rounded as Message,
+  Message_Stroke2_Corner0_Rounded_Filled as MessageFilled,
+} from '#/components/icons/Message'
+import {
+  Bell_Stroke2_Corner0_Rounded as Bell,
+  Bell_Filled_Corner0_Rounded as BellFilled,
+} from '#/components/icons/Bell'
+import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 
@@ -38,6 +48,8 @@ function HomeHeaderLayoutDesktopAndTablet({
   const pal = usePalette('default')
   const {headerHeight} = useShellLayout()
   const {hasSession} = useSession()
+  const unreadMessages = useUnreadMessageCount()
+  const unreadNotifications = useUnreadNotifications()
   const {_} = useLingui()
   const gutters = useGutters([0, 'base'])
 
@@ -58,17 +70,51 @@ function HomeHeaderLayoutDesktopAndTablet({
                 TÜRKLAW
               </Text>
             </View>
-            <Link
-              to="/feeds"
-              hitSlop={10}
-              label={_(msg`View your feeds and explore more`)}
-              size="small"
-              variant="ghost"
-              color="secondary"
-              shape="square"
-              style={[a.justify_center]}>
-              <ButtonIcon icon={FeedsIcon} size="lg" />
-            </Link>
+            <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+              <Link
+                to="/messages"
+                hitSlop={10}
+                label={_(msg`Chat`)}
+                size="small"
+                variant="ghost"
+                color="secondary"
+                shape="square"
+                style={[a.justify_center, {position: 'relative'}]}>
+                <ButtonIcon icon={Message} size="lg" />
+                {unreadMessages.numUnread > 0 && (
+                  <View style={[styles.badge]}>
+                    <Text style={styles.badgeLabel}>{unreadMessages.numUnread}</Text>
+                  </View>
+                )}
+              </Link>
+              <Link
+                to="/notifications"
+                hitSlop={10}
+                label={_(msg`Notifications`)}
+                size="small"
+                variant="ghost"
+                color="secondary"
+                shape="square"
+                style={[a.justify_center, {position: 'relative'}]}>
+                <ButtonIcon icon={Bell} size="lg" />
+                {unreadNotifications !== '' && (
+                  <View style={[styles.badge]}>
+                    <Text style={styles.badgeLabel}>{unreadNotifications}</Text>
+                  </View>
+                )}
+              </Link>
+              <Link
+                to="/feeds"
+                hitSlop={10}
+                label={_(msg`View your feeds and explore more`)}
+                size="small"
+                variant="ghost"
+                color="secondary"
+                shape="square"
+                style={[a.justify_center]}>
+                <ButtonIcon icon={FeedsIcon} size="lg" />
+              </Link>
+            </View>
           </View>
         </Layout.Center>
       )}
@@ -83,3 +129,24 @@ function HomeHeaderLayoutDesktopAndTablet({
     </>
   )
 }
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    backgroundColor: '#ff3b30',
+    minWidth: 14,
+    height: 14,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 2,
+  },
+  badgeLabel: {
+    color: 'white',
+    fontSize: 10,
+    fontWeight: 'bold',
+    lineHeight: 12,
+  },
+})

--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -1,4 +1,4 @@
-import {View} from 'react-native'
+import {View, StyleSheet} from 'react-native'
 import Animated from 'react-native-reanimated'
 
 import {PressableScale} from '#/lib/custom-animations/PressableScale'
@@ -11,6 +11,12 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from '#/lib/ThemeContext'
 import {atoms as a} from '#/alf'
 import * as Layout from '#/components/Layout'
+import {ButtonIcon} from '#/components/Button'
+import {Link} from '#/components/Link'
+import {Message_Stroke2_Corner0_Rounded as Message} from '#/components/icons/Message'
+import {Bell_Stroke2_Corner0_Rounded as Bell} from '#/components/icons/Bell'
+import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 
 export function HomeHeaderLayoutMobile({
   children,
@@ -23,6 +29,8 @@ export function HomeHeaderLayoutMobile({
   const {headerHeight} = useShellLayout()
   const headerMinimalShellTransform = useMinimalShellHeaderTransform()
   const playHaptic = useHaptics()
+  const unreadMessages = useUnreadMessageCount()
+  const unreadNotifications = useUnreadNotifications()
 
   return (
     <Animated.View
@@ -63,9 +71,59 @@ export function HomeHeaderLayoutMobile({
           </PressableScale>
         </View>
 
-        <Layout.Header.Slot />
+        <Layout.Header.Slot>
+          <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+            <Link
+              to="/messages"
+              hitSlop={10}
+              label="Chat"
+              style={[{position: 'relative'}]}
+              PressableComponent={PressableScale}>
+              <ButtonIcon icon={Message} size="lg" />
+              {unreadMessages.numUnread > 0 && (
+                <View style={styles.badge}>
+                  <Text style={styles.badgeLabel}>{unreadMessages.numUnread}</Text>
+                </View>
+              )}
+            </Link>
+            <Link
+              to="/notifications"
+              hitSlop={10}
+              label="Notifications"
+              style={[{position: 'relative'}]}
+              PressableComponent={PressableScale}>
+              <ButtonIcon icon={Bell} size="lg" />
+              {unreadNotifications !== '' && (
+                <View style={styles.badge}>
+                  <Text style={styles.badgeLabel}>{unreadNotifications}</Text>
+                </View>
+              )}
+            </Link>
+          </View>
+        </Layout.Header.Slot>
       </Layout.Header.Outer>
       {children}
     </Animated.View>
   )
 }
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    backgroundColor: '#ff3b30',
+    minWidth: 14,
+    height: 14,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 2,
+  },
+  badgeLabel: {
+    color: 'white',
+    fontSize: 10,
+    fontWeight: 'bold',
+    lineHeight: 12,
+  },
+})

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -248,73 +248,10 @@ export function BottomBar({navigation}: BottomTabBarProps) {
               accessibilityLabel={_(msg`Feeds`)}
             />
             <Btn
-              testID="bottomBarMessagesBtn"
-              icon={
-                isAtMessages ? (
-                  <MessageFilled
-                    width={iconWidth - 1}
-                    style={[styles.ctrlIcon, pal.text, styles.feedsIcon]}
-                  />
-                ) : (
-                  <Message
-                    width={iconWidth - 1}
-                    style={[styles.ctrlIcon, pal.text, styles.feedsIcon]}
-                  />
-                )
-              }
-              onPress={onPressMessages}
-              notificationCount={numUnreadMessages.numUnread}
-              hasNew={numUnreadMessages.hasNew}
-              accessible={true}
-              accessibilityRole="tab"
-              accessibilityLabel={_(msg`Chat`)}
-              accessibilityHint={
-                numUnreadMessages.count > 0
-                  ? _(
-                      msg`${plural(numUnreadMessages.numUnread ?? 0, {
-                        one: '# unread item',
-                        other: '# unread items',
-                      })}` || '',
-                    )
-                  : ''
-              }
-            />
-            <Btn
               icon={<Briefcase width={iconWidth} style={[styles.ctrlIcon, pal.text]} />}
               onPress={onPressJobs}
               accessibilityRole="tab"
               accessibilityLabel={_(msg`Jobs`)}
-            />
-            <Btn
-              testID="bottomBarNotificationsBtn"
-              icon={
-                isAtNotifications ? (
-                  <BellFilled
-                    width={iconWidth}
-                    style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
-                  />
-                ) : (
-                  <Bell
-                    width={iconWidth}
-                    style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
-                  />
-                )
-              }
-              onPress={onPressNotifications}
-              notificationCount={numUnreadNotifications}
-              accessible={true}
-              accessibilityRole="tab"
-              accessibilityLabel={_(msg`Notifications`)}
-              accessibilityHint={
-                numUnreadNotifications === ''
-                  ? ''
-                  : _(
-                      msg`${plural(numUnreadNotifications ?? 0, {
-                        one: '# unread item',
-                        other: '# unread items',
-                      })}` || '',
-                    )
-              }
             />
             <Btn
               testID="bottomBarProfileBtn"

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -14,7 +14,6 @@ import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {useGate} from '#/lib/statsig/statsig'
 import {useHomeBadge} from '#/state/home-badge'
 import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useShellLayout} from '#/state/shell/shell-layout'
@@ -56,7 +55,6 @@ export function BottomBarWeb() {
   const iconWidth = 26
 
   const unreadMessageCount = useUnreadMessageCount()
-  const notificationCountStr = useUnreadNotifications()
   const hasHomeBadge = useHomeBadge()
   const gate = useGate()
 
@@ -148,41 +146,6 @@ export function BottomBarWeb() {
 
           {hasSession && (
             <>
-              <NavItem
-                routeName="Messages"
-                href="/messages"
-                notificationCount={unreadMessageCount.numUnread}
-                hasNew={unreadMessageCount.hasNew}>
-                {({isActive}) => {
-                  const Icon = isActive ? MessageFilled : Message
-                  return (
-                    <Icon
-                      aria-hidden={true}
-                      width={iconWidth - 1}
-                      style={[
-                        styles.ctrlIcon,
-                        t.atoms.text,
-                        styles.messagesIcon,
-                      ]}
-                    />
-                  )
-                }}
-              </NavItem>
-              <NavItem
-                routeName="Notifications"
-                href="/notifications"
-                notificationCount={notificationCountStr}>
-                {({isActive}) => {
-                  const Icon = isActive ? BellFilled : Bell
-                  return (
-                    <Icon
-                      aria-hidden={true}
-                      width={iconWidth}
-                      style={[styles.ctrlIcon, t.atoms.text, styles.bellIcon]}
-                    />
-                  )
-                }}
-              </NavItem>
               <NavItem
                 routeName="Profile"
                 href={


### PR DESCRIPTION
## Summary
- show Messages and Notifications icons in the header
- add briefcase Jobs tab with a basic job listings page
- remove message/notification icons from bottom bar
- display trending topics with `#`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687b82d1a4308323bfd7965c051f79bc