### PR TITLE
Add jobs page and update nav icons

### DIFF
--- a/src/screens/Jobs.tsx
+++ b/src/screens/Jobs.tsx
@@ -1,47 +1,29 @@
-import React from 'react'
-import {View, ScrollView} from 'react-native'
-import {Trans} from '@lingui/macro'
-import {Link} from '#/components/Link'
+import {StyleSheet} from 'react-native'
+import {WebView} from 'react-native-webview'
 
+import {isWeb} from '#/platform/detection'
 import * as Layout from '#/components/Layout'
-import {Text} from '#/components/Typography'
-import {atoms as a} from '#/alf'
 
 export default function JobsScreen() {
-  const jobs = [
-    {
-      title: 'Frontend Developer',
-      company: 'Türklaw Inc.',
-      location: 'Istanbul',
-      link: 'https://www.linkedin.com/jobs',
-    },
-    {
-      title: 'Backend Developer',
-      company: 'Türklaw Inc.',
-      location: 'Ankara',
-      link: 'https://www.linkedin.com/jobs',
-    },
-  ]
-
   return (
     <Layout.Screen testID="JobsScreen">
-      <ScrollView contentContainerStyle={[a.p_md, a.gap_md]}>
-        <Text style={[a.text_lg, a.font_bold, a.mb_md]}>
-          <Trans>Job Listings</Trans>
-        </Text>
-        {jobs.map(job => (
-          <Link
-            key={job.title}
-            to={job.link}
-            style={[a.p_md, a.border, a.rounded_md]}
-          >
-            <Text style={[a.text_md, a.font_bold]}>{job.title}</Text>
-            <Text style={[a.text_sm]}>
-              {job.company} - {job.location}
-            </Text>
-          </Link>
-        ))}
-      </ScrollView>
+      {isWeb ? (
+        <iframe
+          src="https://www.linkedin.com/jobs"
+          style={styles.frame}
+          title="LinkedIn Jobs"
+        />
+      ) : (
+        <WebView
+          source={{uri: 'https://www.linkedin.com/jobs'}}
+          style={styles.webview}
+        />
+      )}
     </Layout.Screen>
   )
 }
+
+const styles = StyleSheet.create({
+  webview: {flex: 1},
+  frame: {flex: 1, borderWidth: 0},
+})

--- a/src/view/com/home/HomeHeaderLayout.web.tsx
+++ b/src/view/com/home/HomeHeaderLayout.web.tsx
@@ -1,27 +1,20 @@
-import {View, StyleSheet} from 'react-native'
+import {StyleSheet, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import type React from 'react'
 
+import {usePalette} from '#/lib/hooks/usePalette'
+import {useTheme} from '#/lib/ThemeContext'
+import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 import {useSession} from '#/state/session'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {HomeHeaderLayoutMobile} from '#/view/com/home/HomeHeaderLayoutMobile'
 import {Text} from '#/view/com/util/text/Text'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {atoms as a, useBreakpoints, useGutters} from '#/alf'
-import {useTheme} from '#/lib/ThemeContext'
 import {ButtonIcon} from '#/components/Button'
-import {Hashtag_Stroke2_Corner0_Rounded as FeedsIcon} from '#/components/icons/Hashtag'
-import {
-  Message_Stroke2_Corner0_Rounded as Message,
-  Message_Stroke2_Corner0_Rounded_Filled as MessageFilled,
-} from '#/components/icons/Message'
-import {
-  Bell_Stroke2_Corner0_Rounded as Bell,
-  Bell_Filled_Corner0_Rounded as BellFilled,
-} from '#/components/icons/Bell'
-import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
+import {Bell_Stroke2_Corner0_Rounded as Bell} from '#/components/icons/Bell'
+import {Message_Stroke2_Corner0_Rounded as Message} from '#/components/icons/Message'
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 
@@ -83,7 +76,9 @@ function HomeHeaderLayoutDesktopAndTablet({
                 <ButtonIcon icon={Message} size="lg" />
                 {unreadMessages.numUnread > 0 && (
                   <View style={[styles.badge]}>
-                    <Text style={styles.badgeLabel}>{unreadMessages.numUnread}</Text>
+                    <Text style={styles.badgeLabel}>
+                      {unreadMessages.numUnread}
+                    </Text>
                   </View>
                 )}
               </Link>
@@ -102,17 +97,6 @@ function HomeHeaderLayoutDesktopAndTablet({
                     <Text style={styles.badgeLabel}>{unreadNotifications}</Text>
                   </View>
                 )}
-              </Link>
-              <Link
-                to="/feeds"
-                hitSlop={10}
-                label={_(msg`View your feeds and explore more`)}
-                size="small"
-                variant="ghost"
-                color="secondary"
-                shape="square"
-                style={[a.justify_center]}>
-                <ButtonIcon icon={FeedsIcon} size="lg" />
               </Link>
             </View>
           </View>

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -13,7 +13,6 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {useGate} from '#/lib/statsig/statsig'
 import {useHomeBadge} from '#/state/home-badge'
-import {useUnreadMessageCount} from '#/state/queries/messages/list-conversations'
 import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useShellLayout} from '#/state/shell/shell-layout'
@@ -22,20 +21,13 @@ import {Link} from '#/view/com/util/Link'
 import {Logotype} from '#/view/icons/Logotype'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
-import {
-  Bell_Filled_Corner0_Rounded as BellFilled,
-  Bell_Stroke2_Corner0_Rounded as Bell,
-} from '#/components/icons/Bell'
+import {Briefcase_Stroke2_Corner0_Rounded as Briefcase} from '#/components/icons/Briefcase'
 import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
 } from '#/components/icons/HomeOpen'
 import {MagnifyingGlass_Filled_Stroke2_Corner0_Rounded as MagnifyingGlassFilled} from '#/components/icons/MagnifyingGlass'
 import {MagnifyingGlass2_Stroke2_Corner0_Rounded as MagnifyingGlass} from '#/components/icons/MagnifyingGlass2'
-import {
-  Message_Stroke2_Corner0_Rounded as Message,
-  Message_Stroke2_Corner0_Rounded_Filled as MessageFilled,
-} from '#/components/icons/Message'
 import {
   UserCircle_Filled_Corner0_Rounded as UserCircleFilled,
   UserCircle_Stroke2_Corner0_Rounded as UserCircle,
@@ -54,7 +46,6 @@ export function BottomBarWeb() {
   const hideBorder = useHideBottomBarBorder()
   const iconWidth = 26
 
-  const unreadMessageCount = useUnreadMessageCount()
   const hasHomeBadge = useHomeBadge()
   const gate = useGate()
 
@@ -143,6 +134,16 @@ export function BottomBarWeb() {
               </Text>
             </View>
           </Pressable>
+
+          <NavItem routeName="Jobs" href="/jobs">
+            {() => (
+              <Briefcase
+                aria-hidden={true}
+                width={iconWidth}
+                style={[styles.ctrlIcon, t.atoms.text]}
+              />
+            )}
+          </NavItem>
 
           {hasSession && (
             <>


### PR DESCRIPTION
## Summary
- embed LinkedIn Jobs inside new Jobs screen
- remove feed icon from desktop header
- show Jobs button in web bottom bar

## Testing
- `yarn test`
- `npx eslint src/screens/Jobs.tsx src/view/com/home/HomeHeaderLayout.web.tsx src/view/shell/bottom-bar/BottomBarWeb.tsx --fix`

------
https://chatgpt.com/codex/tasks/task_e_687b930446f88323b8adc580f756bf49